### PR TITLE
#141409247 Convert from Grunt to Gulp taskrunner

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -7,7 +7,7 @@ script(type='text/javascript', src='/lib/jquery/jquery.js')
 script(type='text/javascript', src='/lib/underscore/underscore-min.js')
 
 //	Bootstrap
-script(type='text/javascript', src='/lib/bootstrap/js/bootstrap.js')
+script(type='text/javascript', src='/lib/bootstrap/dist/js/bootstrap.js')
 
 //AngularJS
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular.js')
@@ -16,7 +16,7 @@ script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-coo
 
 //	Angular UI
 script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')
-script(type='text/javascript', src='/lib/angular-ui-utils/modules/route.js')
+script(type='text/javascript', src='/lib/angular-ui-utils/modules/route/route.js')
 
 //	Application Init
 script(type='text/javascript', src='/js/init.js')

--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -23,7 +23,7 @@ head
   meta(property='og:site_name', content='Cards for Humanity')
   meta(property='fb:admins', content='APP_ADMIN')
 
-  link(rel='stylesheet', href='/lib/bootstrap/css/bootstrap.css')
+  link(rel='stylesheet', href='/lib/bootstrap/dist/css/bootstrap.css')
   link(rel='stylesheet', href='/css/common.css')
   link(rel='stylesheet', href='/css/animate.css')
   link(rel='stylesheet', href='/css/style.css')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ const nodemon = require('gulp-nodemon');
 const sass = require('gulp-sass');
 const eslint = require('gulp-eslint');
 const mocha = require('gulp-mocha');
+const bower = require('gulp-bower');
 
 /**
  * Adds two numbers together.
@@ -68,7 +69,11 @@ gulp.task('scss', () => {
   .pipe(gulp.dest('./public/css'));
 });
 
+gulp.task('bower', () => (
+  bower({ directory: './public/lib' })
+));
 
-gulp.task('default', ['reload', 'scss', 'lint'], () => {
+
+gulp.task('default', ['reload', 'scss'], () => {
   gulp.watch(['public/**/**/**'], browserSync.reload());
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "gulp",
     "test": "gulp mocha",
-    "postinstall": ""
+    "postinstall": "gulp bower"
   },
   "dependencies": {
     "async": "~0.2.9",
@@ -63,6 +63,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-mocha-test": "~0.7.0",
     "grunt-nodemon": "~0.1.1",
+    "gulp-bower": "0.0.13",
     "gulp-eslint": "^3.0.1",
     "gulp-mocha": "^4.1.0",
     "gulp-nodemon": "^2.2.1",


### PR DESCRIPTION
#### What does this PR do?
- Updates `gulpfile.js` to include task to install bower dependencies into `public/lib` folder.
- Updates `app/views/includes/foot.jade` and `app/views/includes/head.jade` to correct the path to dependencies
- Updates the package.json file to add dependencies 

#### Description of Task to be completed?
- Grunt is an older task runner than Gulp; with Gulp, the syntax is much simpler to comprehend and it uses pipe streams which makes it inherently faster.

#### How should this be manually tested?
- Install` gulp`, `gulp-cli` and `browser-sync`  globally using `npm install -g  gulp gulp-cli browser-sync`
#### Any background context you want to provide?
- References to angular modules like `ngRoute` and bootsrap references were not working and the 
#### What are the relevant pivotal tracker stories?
- Convert from Grunt to Gulp taskrunner
#### Screenshots (if appropriate)
- NA
#### Questions:
- NA