### PR TITLE
#141409247 Convert from Grunt to Gulp taskrunner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "6"
 before_script:
   - nvm install 6
-  - bower install
   - npm install
   - npm install -g gulp
+  - gulp
 script: gulp mocha

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   - nvm install 6
   - npm install
   - npm install -g gulp
-  - gulp
+  - gulp bower
 script: gulp mocha

--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -3,11 +3,11 @@ script.
       (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
       g.src='//www.google-analytics.com/ga.js';
       s.parentNode.insertBefore(g,s)}(document,'script'));
-script(type='text/javascript', src='/lib/jquery/jquery.js')
-script(type='text/javascript', src='/lib/underscore/underscore-min.js')
+script(type='text/javascript', src='../lib/jquery/jquery.js')
+script(type='text/javascript', src='../lib/underscore/underscore-min.js')
 
 //	Bootstrap
-script(type='text/javascript', src='/lib/bootstrap/dist/js/bootstrap.js')
+script(type='text/javascript', src='../lib/bootstrap/dist/js/bootstrap.js')
 
 //AngularJS
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular.js')
@@ -15,25 +15,25 @@ script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-res
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-cookies.js')
 
 //	Angular UI
-script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')
-script(type='text/javascript', src='/lib/angular-ui-utils/modules/route/route.js')
+script(type='text/javascript', src='../lib/angular-bootstrap/ui-bootstrap-tpls.js')
+script(type='text/javascript', src='../lib/angular-ui-utils/modules/route/route.js')
 
 //	Application Init
-script(type='text/javascript', src='/js/init.js')
-script(type='text/javascript', src='/js/app.js')
-script(type='text/javascript', src='/js/directives.js')
-script(type='text/javascript', src='/js/filters.js')
+script(type='text/javascript', src='../js/init.js')
+script(type='text/javascript', src='../js/app.js')
+script(type='text/javascript', src='../js/directives.js')
+script(type='text/javascript', src='../js/filters.js')
 
 //	Application Services
-script(type='text/javascript', src='/js/services/global.js')
-script(type='text/javascript', src='/js/services/socket.js')
-script(type='text/javascript', src='/js/services/game.js')
+script(type='text/javascript', src='../js/services/global.js')
+script(type='text/javascript', src='../js/services/socket.js')
+script(type='text/javascript', src='../js/services/game.js')
 
 //	Application Controllers
-script(type='text/javascript', src='/js/controllers/index.js')
-script(type='text/javascript', src='/js/controllers/header.js')
-script(type='text/javascript', src='/js/controllers/game.js')
-script(type='text/javascript', src='/js/init.js')
+script(type='text/javascript', src='../js/controllers/index.js')
+script(type='text/javascript', src='../js/controllers/header.js')
+script(type='text/javascript', src='../js/controllers/game.js')
+script(type='text/javascript', src='../js/init.js')
 
 //	Socket.io Client Library
 script(type='text/javascript', src='/socket.io/socket.io.js')

--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -23,10 +23,10 @@ head
   meta(property='og:site_name', content='Cards for Humanity')
   meta(property='fb:admins', content='APP_ADMIN')
 
-  link(rel='stylesheet', href='/lib/bootstrap/dist/css/bootstrap.css')
-  link(rel='stylesheet', href='/css/common.css')
-  link(rel='stylesheet', href='/css/animate.css')
-  link(rel='stylesheet', href='/css/style.css')
+  link(rel='stylesheet', href='../lib/bootstrap/dist/css/bootstrap.css')
+  link(rel='stylesheet', href='../css/common.css')
+  link(rel='stylesheet', href='../css/animate.css')
+  link(rel='stylesheet', href='../css/style.css')
 
 
   //if lt IE 9

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,6 +74,6 @@ gulp.task('bower', () => (
 ));
 
 
-gulp.task('default', ['reload', 'scss'], () => {
+gulp.task('default', ['bower', 'scss', 'reload'], () => {
   gulp.watch(['public/**/**/**'], browserSync.reload());
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,6 +74,6 @@ gulp.task('bower', () => (
 ));
 
 
-gulp.task('default', ['bower', 'scss', 'reload'], () => {
+gulp.task('default', ['scss', 'reload'], () => {
   gulp.watch(['public/**/**/**'], browserSync.reload());
 });


### PR DESCRIPTION
#What does this PR do?
- Updates `gulpfile.js` to include task to install bower dependencies into `public/lib` folder.
- Updates `app/views/includes/foot.jade` and `app/views/includes/head.jade` to correct the path to dependencies
- Updates the `package.json` file to add dependencies

#Description of Task to be completed?
- Grunt is an older task runner than Gulp; with Gulp, the syntax is much simpler to comprehend and it uses pipe streams which makes it inherently faster.

#How should this be manually tested?
- Install `gulp`, `gulp-cli` and `browser-sync` globally using `npm install -g gulp gulp-cli browser-sync`

#Any background context you want to provide?
- References to angular modules like `ngRoute` and `bootsrap` references were not working hence the need to update the view's `header.jade` and `footer.jade` file to point to the right URL

#What are the relevant pivotal tracker stories?
- Convert from Grunt to Gulp taskrunner

#Screenshots (if appropriate)
- NA

#Questions:
- NA