### PR TITLE
chore/141409247/convert-grunt-to-gulp 

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "public/lib"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "6"
 before_script:
   - nvm install 6
-  - npm install
   - npm install -g gulp
-  - gulp bower
+  - npm install
 script: gulp mocha

--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -3,11 +3,11 @@ script.
       (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
       g.src='//www.google-analytics.com/ga.js';
       s.parentNode.insertBefore(g,s)}(document,'script'));
-script(type='text/javascript', src='../lib/jquery/jquery.js')
-script(type='text/javascript', src='../lib/underscore/underscore-min.js')
+script(type='text/javascript', src='/lib/jquery/jquery.js')
+script(type='text/javascript', src='/lib/underscore/underscore-min.js')
 
 //	Bootstrap
-script(type='text/javascript', src='../lib/bootstrap/dist/js/bootstrap.js')
+script(type='text/javascript', src='/lib/bootstrap/dist/js/bootstrap.js')
 
 //AngularJS
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular.js')
@@ -15,25 +15,25 @@ script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-res
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-cookies.js')
 
 //	Angular UI
-script(type='text/javascript', src='../lib/angular-bootstrap/ui-bootstrap-tpls.js')
-script(type='text/javascript', src='../lib/angular-ui-utils/modules/route/route.js')
+script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')
+script(type='text/javascript', src='/lib/angular-ui-utils/modules/route/route.js')
 
 //	Application Init
-script(type='text/javascript', src='../js/init.js')
-script(type='text/javascript', src='../js/app.js')
-script(type='text/javascript', src='../js/directives.js')
-script(type='text/javascript', src='../js/filters.js')
+script(type='text/javascript', src='/js/init.js')
+script(type='text/javascript', src='/js/app.js')
+script(type='text/javascript', src='/js/directives.js')
+script(type='text/javascript', src='/js/filters.js')
 
 //	Application Services
-script(type='text/javascript', src='../js/services/global.js')
-script(type='text/javascript', src='../js/services/socket.js')
-script(type='text/javascript', src='../js/services/game.js')
+script(type='text/javascript', src='/js/services/global.js')
+script(type='text/javascript', src='/js/services/socket.js')
+script(type='text/javascript', src='/js/services/game.js')
 
 //	Application Controllers
-script(type='text/javascript', src='../js/controllers/index.js')
-script(type='text/javascript', src='../js/controllers/header.js')
-script(type='text/javascript', src='../js/controllers/game.js')
-script(type='text/javascript', src='../js/init.js')
+script(type='text/javascript', src='/js/controllers/index.js')
+script(type='text/javascript', src='/js/controllers/header.js')
+script(type='text/javascript', src='/js/controllers/game.js')
+script(type='text/javascript', src='/js/init.js')
 
 //	Socket.io Client Library
 script(type='text/javascript', src='/socket.io/socket.io.js')

--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -23,10 +23,10 @@ head
   meta(property='og:site_name', content='Cards for Humanity')
   meta(property='fb:admins', content='APP_ADMIN')
 
-  link(rel='stylesheet', href='../lib/bootstrap/dist/css/bootstrap.css')
-  link(rel='stylesheet', href='../css/common.css')
-  link(rel='stylesheet', href='../css/animate.css')
-  link(rel='stylesheet', href='../css/style.css')
+  link(rel='stylesheet', href='/lib/bootstrap/dist/css/bootstrap.css')
+  link(rel='stylesheet', href='/css/common.css')
+  link(rel='stylesheet', href='/css/animate.css')
+  link(rel='stylesheet', href='/css/style.css')
 
 
   //if lt IE 9

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,3 +77,5 @@ gulp.task('bower', () => (
 gulp.task('default', ['scss', 'reload'], () => {
   gulp.watch(['public/**/**/**'], browserSync.reload());
 });
+
+gulp.task('install', ['bower']);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "gulp",
     "test": "gulp mocha",
-    "postinstall": "gulp bower"
+    "postinstall": "gulp install"
   },
   "dependencies": {
     "async": "~0.2.9",
@@ -32,6 +32,7 @@
     "grunt-bower-task": "~0.4.0",
     "grunt-cli": "~0.1.9",
     "gulp": "^3.9.1",
+    "gulp-jade": "^1.1.0",
     "gulp-sass": "^3.1.0",
     "jade": "~0.35.0",
     "jsonwebtoken": "^7.3.0",


### PR DESCRIPTION
#What does this PR do?
- Added bower configuration file `.bowerrc` to install bower dependencies into `public/lib` folder
- Modifies `package.json` to run `gulp bower` after `npm install`
- Updates `gulpfile.js` to include task to install bower dependencies into public/lib folder.
- Updates `app/views/includes/foot.jade` and `app/views/includes/head.jade` to correct the path to dependencies

#Description of Task to be completed?
 - Grunt is an older task runner than Gulp; with Gulp, the syntax is much simpler to comprehend and  it uses pipe streams which makes it inherently faster.

#How should this be manually tested?
- Install `gulp`, `gulp-cli` and `browser-sync` globally using `npm install -g gulp gulp-cli browser-sync`

#Any background context you want to provide?
- References to angular modules like `ngRoute` and `bootsrap` were not working hence the need to update the view's `header.jade` and `footer.jade` file to point to the right URL

#What are the relevant pivotal tracker stories?
- Convert from Grunt to Gulp taskrunner

#Screenshots (if appropriate)
- NA

#Questions:
- NA