### PR TITLE
#141409261 Users Able to Start/Create New Game

### DIFF
--- a/app/models/gameRecord.js
+++ b/app/models/gameRecord.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const gameRecordSchema = new Schema({
+  gamePlayDate: String,
+  gameID: String,
+  gamePlayers: [],
+  gameRounds: Number,
+  winner: String
+});
+
+module.exports = mongoose.model('Record', gameRecordSchema);

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -23,7 +23,8 @@ var UserSchema = new Schema({
     facebook: {},
     twitter: {},
     github: {},
-    google: {}
+    google: {},
+    gameRecord: {}
 });
 
 /**

--- a/config/routes.js
+++ b/config/routes.js
@@ -66,12 +66,41 @@ module.exports = function(app, passport, auth) {
       });
     });
 
-    app.post('/inviteusers', middleware.requiresLogin, (req) => {
+    app.post('/inviteusers', middleware.requiresLogin, (req, res) => {
       const url = req.body.url;
       const userEmail = req.body.invitee;
       const gameOwner = req.body.gameOwner;
 
       sendMail(userEmail, url, gameOwner);
+      res.send(`Invite sent to ${userEmail}`);
+    });
+
+    app.post('/api/games/:id/start', middleware.requiresLogin, (req, res) => {
+      const gameRounds = req.body.gameRounds;
+      const gameOwner = req.body.gameOwner;
+      const winner = req.body.gameWinner;
+      const gamePlayers = req.body.gamePlayers;
+      const gameID = req.params.id;
+
+      const gameStats = {
+        [gameID]: {
+          gameRounds,
+          gameOwner,
+          winner,
+          gamePlayers
+        }
+      };
+
+      User.findOneAndUpdate({ name: gameOwner },
+        {
+          $push: { gameRecord: gameStats }
+        }, (error) => {
+          if (error) {
+            res.send('An error occured.');
+          } else {
+            res.send(`Game ${gameID} has been successfully recorded`);
+          }
+        });
     });
 
     // Donation Routes

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -189,11 +189,17 @@ angular.module('mean.system')
       return $scope.userMatches;
     };
 
+    $scope.startGameChoice = false;
+
     $scope.startGame = () => {
       if (game.players.length >= game.playerMinLimit
               && game.players.length < game.playerMaxLimit) {
-        $scope.gameStarted = true;
-        game.startGame();
+        displayMessage('You are about to start a new game. ' +
+         'Do you want to continue?', '#message-modal');
+
+        if ($scope.startGameChoice) {
+          game.startGame();
+        }
       } else {
         const minNumberOfPlayersLeft =
             game.playerMinLimit - game.players.length;

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -199,6 +199,7 @@ angular.module('mean.system')
 
         if ($scope.startGameChoice) {
           game.startGame();
+          $scope.showInviteButton = false;
         }
       } else {
         const minNumberOfPlayersLeft =

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -1,6 +1,6 @@
 angular.module('mean.system')
-  .factory('game', ['socket', '$timeout', function (socket, $timeout) {
-
+  .factory('game', ['socket', '$timeout', '$http',
+    (socket, $timeout, $http) => {
   var game = {
     id: null, // This player's socket ID, so we know who this player is
     gameID: null,
@@ -170,6 +170,21 @@ angular.module('mean.system')
     } else if (data.state === 'game dissolved' || data.state === 'game ended') {
       game.players[game.playerIndex].hand = [];
       game.time = 0;
+
+      const gameRounds = game.round;
+      const gameOwner = game.players[0].username;
+      const gameWinner = game.players[game.gameWinner].username;
+      const gamePlayers = game.players.slice(1).map(player => player.username);
+      const gameID = game.gameID;
+
+      const gameRecord = {
+        gameRounds,
+        gameOwner,
+        gameWinner,
+        gamePlayers
+      };
+
+      $http.post(`/api/games/${gameID}/start`, gameRecord);
     }
   });
 

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -171,15 +171,15 @@ angular.module('mean.system')
       game.players[game.playerIndex].hand = [];
       game.time = 0;
 
+      const gamePlayDate = new Date();
       const gameRounds = game.round;
-      const gameOwner = game.players[0].username;
       const gameWinner = game.players[game.gameWinner].username;
-      const gamePlayers = game.players.slice(1).map(player => player.username);
+      const gamePlayers = game.players.map(player => player.username);
       const gameID = game.gameID;
 
       const gameRecord = {
+        gamePlayDate,
         gameRounds,
-        gameOwner,
         gameWinner,
         gamePlayers
       };

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -9,7 +9,7 @@
             <p>{{message}}</p>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-primary pull-right" data-dismiss="modal" style="background-color: #B22222; border:none;">Close</button>
           </div>
         </div>
 
@@ -46,11 +46,29 @@
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary pull-right" data-dismiss="modal" style="background-color: #B22222; border:none;">Close</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+  <div id="message-modal" class="modal fade" role="dialog">
+        <div class="modal-dialog">
+          <!-- Modal content-->
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title" style="color: #800000">Be sure not to crash a spaceship.</h4>
+            </div>
+            <div class="modal-body">
+              <p>{{message}}</p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" data-dismiss="modal" style="background-color: #B22222; border:none;">Close</button>
+              <button type="button" class="btn btn-primary" data-dismiss="modal" ng-click="startGameChoice = true; startGame();">Join the Rough Ride</button>
+            </div>
           </div>
         </div>
-
       </div>
-    </div>
 
 <div id="question-container-inner">
   <div class="card longBlack">
@@ -68,7 +86,7 @@
       <div id="loading-container">
         <div id="loading-gif"><img ng-src="../img/loader.gif"/></div>
       </div>
-      <div id="start-game-container" ng-click="startGame()">
+      <div id="start-game-container" ng-click="startGame()" ng-show="(game.playerIndex === 0 || game.joinOverride)">
         <div id='start-game-button'>
           Start Game
         </div>


### PR DESCRIPTION
#### What does this PR do?
Implements the feature 'Users should be able to create/start a new game'.

#### Description of Task to be completed?
- Users should be able to start a new game session after login or signup
- When users click an appropriately labelled button, they start a new game session
- Requires a modal that lets the user know that clicking the button would start a new game session
- Requires an authenticated endpoint /api/games/:id/start and should be recorded for that user as well as the friends that played in that game and the winner of that game

#### How should this be manually tested?
- Visit the review app on [Might-Guy-Cfh](http://might-guy-cfh-staging-pr-32.herokuapp.com/)
- Sign up/log in 
- Choose to play
- Once there are at least 3 players in the game and you try to start, you should get a pop up telling you you are about to start a new game.

#### Any background context you want to provide?
Previously, the game threw users into a new gaming screen and starts the game off immediately, which creates a rather confusing experience for the user.

#### What are the relevant pivotal tracker stories?
#141409261 - Users should be able to create/start a new game

#### Screenshots (if appropriate)
NA
#### Questions:
NA